### PR TITLE
optimised solidity contract

### DIFF
--- a/mood.sol
+++ b/mood.sol
@@ -1,21 +1,15 @@
 //specify the version of solidity
 pragma solidity ^0.8.1;
 
-/// a simple set and get function for mood defined: 
+/// a simple set and get function for mood defined:
 
 //define the contract
-contract MoodDiary{
-    
+contract MoodDiary {
     //create a variable called mood
-    string mood;
-    
+    string public mood;
+
     //create a function that writes a mood to the smart contract
-    function setMood(string memory _mood) public{
+    function setMood(string memory _mood) public {
         mood = _mood;
-    }
-    
-    //create a function the reads the mood from the smart contract
-    function getMood() public view returns(string memory){
-        return mood;
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ provider.send("eth_requestAccounts", []).then(() => {
 });
 
 async function getMood() {
-  const getMoodPromise = MoodContract.getMood();
+  const getMoodPromise = MoodContract.mood();
   const Mood = await getMoodPromise;
   document.getElementById("console").innerText = `The mood is ${Mood}.`;
   console.log(Mood);


### PR DESCRIPTION
since solidity public variables generate their own getters by default (solidity ver > 0.8), no need write getter variables as it will take more bytecode => more gas to deploy.